### PR TITLE
FIX: Hotfix automatic version number

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "noetictools.git2semver.tool": {
+      "version": "1.1.0",
+      "commands": [
+        "git2semver"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,31 @@
+<!--
+    Directory.Props
+
+    This file centralizes common project properties and GitVersion configuration
+    for all projects in the solution. It sets the repository path, enables GitVersion integration,
+    and defines version properties that are automatically populated by Git2SemVer (a modified version
+    of MSBuild for Visual Studio 6.0+). The RunScript property is disabled since no custom Git2SemVer
+    script is used.
+-->
+
 <Project>
-  <PropertyGroup>
-    <!-- Set the repository path (the folder containing the .git folder) -->
-    <GitVersion_RepositoryPath>C:\Users\tyler\Desktop\Workspace\GitHub\Morven_Compatch_NFR_Patcher\Morven_Compatch_NFR_Patcher</GitVersion_RepositoryPath>
-  </PropertyGroup>
+	<PropertyGroup>
+		
+		<!-- Set the repository path -->
+		<GitVersion_RepositoryPath>$(SolutionDir)</GitVersion_RepositoryPath>
+
+		<!-- Enable GitVersion integration globally -->
+		<UseGitVersion>true</UseGitVersion>
+		<GitVersion_UpdateAssemblyInfo>true</GitVersion_UpdateAssemblyInfo>
+
+		<!-- Version properties to be populated by Git2SemVer (A modified version of MSBuild to work with Visual Studio 6.0+) -->
+		<Version>$(GitVersion_SemVer)</Version>
+		<AssemblyVersion>$(GitVersion_AssemblySemVer)</AssemblyVersion>
+		<FileVersion>$(GitVersion_AssemblySemFileVer)</FileVersion>
+		<InformationalVersion>$(GitVersion_InformationalVersion)</InformationalVersion>
+
+		<!-- No custom Git2SemVer script, disable script execution -->
+		<RunScript>false</RunScript>
+		
+	</PropertyGroup>
 </Project>

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -21,9 +21,9 @@ branches:
   hotfix:
     # Matches hotfix branches that start with "hotfix-" or "hotfix/".
     regex: ^hotfix(es)?[/-]
-    tag-prefix: beta
     increment: Patch
     source-branches:
       - master
+      - dev
 ignore:
   sha: []

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -21,6 +21,7 @@ branches:
   hotfix:
     # Matches hotfix branches that start with "hotfix-" or "hotfix/".
     regex: ^hotfix(es)?[/-]
+    tag-prefix: beta
     increment: Patch
     source-branches:
       - master

--- a/Morven_Compatch_NFR_Patcher.Desktop/Morven_Compatch_NFR_Patcher.Desktop.csproj
+++ b/Morven_Compatch_NFR_Patcher.Desktop/Morven_Compatch_NFR_Patcher.Desktop.csproj
@@ -1,58 +1,29 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
-	<!-- PropertyGroup defines project-wide settings -->
 	<PropertyGroup>
-
-		<!-- Produce a Windows executable -->
+		
+		<!-- Generate a Windows executable targeting .NET 8.0 -->
 		<OutputType>WinExe</OutputType>
-
-		<!-- Target .NET 8.0 -->
 		<TargetFramework>net8.0</TargetFramework>
-
-		<!-- Specify the application manifest and icon -->
 		<ApplicationManifest>app.manifest</ApplicationManifest>
+
+		<!-- Give the window a name and a icon that goes with it -->
 		<ApplicationIcon>Assets\author.ico</ApplicationIcon>
-
-		<!-- Assembly name for the output executable -->
 		<AssemblyName>Morven Compatch NFR</AssemblyName>
-
-		<!-- Enable GitVersion integration -->
-		<UseGitVersion>true</UseGitVersion>
-
-		<!-- 
-			Tell GitVersion to use the solution directory (which now contains the .git folder and GitVersion.yml)
-			as both the repository path and working directory.
-			$(SolutionDir) is a built-in MSBuild property that points to the directory containing the solution file.
-		-->
-		<GitVersion_RepositoryPath>$(SolutionDir)</GitVersion_RepositoryPath>
-		<GitVersion_WorkingDirectory>$(SolutionDir)</GitVersion_WorkingDirectory>
-		<GitVersion_OverrideWorkingDirectory>true</GitVersion_OverrideWorkingDirectory>
-
-		<!-- 
-		  These version properties are automatically populated by GitVersion.MsBuild 
-		  based on the Git history and the GitVersion.yml configuration.
-		-->
-		<Version>$(GitVersion_SemVer)</Version>
-		<AssemblyVersion>$(GitVersion_AssemblySemVer)</AssemblyVersion>
-		<FileVersion>$(GitVersion_AssemblySemFileVer)</FileVersion>
-		<InformationalVersion>$(GitVersion_InformationalVersion)</InformationalVersion>
 	</PropertyGroup>
 
-	<!-- ItemGroup for NuGet package and project references -->
 	<ItemGroup>
-
-		<!-- Avalonia.Desktop is required for a WinExe Avalonia app -->
+		
+		<!-- Required for Avalonia desktop apps -->
 		<PackageReference Include="Avalonia.Desktop" Version="11.2.3" />
-
-		<!-- GitVersion.MsBuild integrates GitVersion into the build process -->
-		<PackageReference Include="GitVersion.MsBuild" Version="6.1.0" PrivateAssets="all" />
-
-		<!-- Reference the library project containing core functionality -->
+		
+		<!-- Git2SemVer integration (A modified version of MSBuild to work with Visual Studio 6.0+) -->
+		<PackageReference Include="NoeticTools.Git2SemVer.MSBuild" Version="2.0.0" />
+		
+		<!-- Reference to the core library project -->
 		<ProjectReference Include="..\Morven_Compatch_NFR_Patcher\Morven_Compatch_NFR_Patcher.csproj" />
-
-		<!-- Include the Assets folder  -->
+		
+		<!-- Include asset files -->
 		<Folder Include="Assets\" />
-
+		
 	</ItemGroup>
-
 </Project>

--- a/Morven_Compatch_NFR_Patcher.Desktop/Program.cs
+++ b/Morven_Compatch_NFR_Patcher.Desktop/Program.cs
@@ -1,23 +1,35 @@
-﻿using System;
+﻿/*=============================================================================================*
+*   Class: Program
+*
+*   Description: This class serves as the entry point for the Avalonia desktop application.
+*      It contains the Main method which initializes the Avalonia framework and starts the
+*      application using a classic desktop lifetime. The BuildAvaloniaApp method configures the
+*      Avalonia AppBuilder with platform detection, a custom font (Inter), and logging support.
+*
+*   Note: Avoid using Avalonia, third-party APIs, or any SynchronizationContext-reliant code 
+*         before the application is fully initialized. All such initialization should occur 
+*         after AppMain is called.
+*=============================================================================================*/
 
+using System;
 using Avalonia;
 
-namespace Morven_Compatch_NFR_Patcher.Desktop;
-
-class Program
+namespace Morven_Compatch_NFR_Patcher.Desktop
 {
-    // Initialization code. Don't use any Avalonia, third-party APIs or any
-    // SynchronizationContext-reliant code before AppMain is called: things aren't initialized
-    // yet and stuff might break.
-    [STAThread]
-    public static void Main(string[] args) => BuildAvaloniaApp()
-        .StartWithClassicDesktopLifetime(args);
+    class Program
+    {
+        // Entry point of the application.
+        // This method sets up and starts the Avalonia application with a classic desktop lifetime.
+        [STAThread]
+        public static void Main(string[] args) => BuildAvaloniaApp()
+            .StartWithClassicDesktopLifetime(args);
 
-    // Avalonia configuration, don't remove; also used by visual designer.
-    public static AppBuilder BuildAvaloniaApp()
-        => AppBuilder.Configure<App>()
-            .UsePlatformDetect()
-            .WithInterFont()
-            .LogToTrace();
-
+        // Configures and returns an Avalonia AppBuilder instance.
+        // This method sets up platform detection, custom font integration, and logging.
+        public static AppBuilder BuildAvaloniaApp()
+            => AppBuilder.Configure<App>()
+                .UsePlatformDetect()
+                .WithInterFont()
+                .LogToTrace();
+    }
 }

--- a/Morven_Compatch_NFR_Patcher/App.axaml.cs
+++ b/Morven_Compatch_NFR_Patcher/App.axaml.cs
@@ -1,16 +1,16 @@
 ﻿/*=============================================================================================*
-* Class: App
+*   Class: App
 *
-* Description:
-*   This class is the main application entry point for the Morven Compatch NFR Patcher.
-*   It extends Avalonia's Application class and is responsible for loading the XAML resources,
-*   initializing the application's framework, and setting up the main window based on the type 
-*   of application lifetime.
+*   Description:
+*       This class is the main application entry point for the Morven Compatch NFR Patcher.
+*       It extends Avalonia's Application class and is responsible for loading the XAML resources,
+*       initializing the application's framework, and setting up the main window based on the type 
+*       of application lifetime.
 *
-*   When the framework initialization is completed, it removes extra Avalonia data validation 
-*   to prevent duplicate validation errors, then checks whether the app is running in classic 
-*   desktop mode or single-view mode, and finally creates and assigns the appropriate main window 
-*   or view with its DataContext set to a new instance of MainViewModel.
+*       When the framework initialization is completed, it removes extra Avalonia data validation 
+*       to prevent duplicate validation errors, then checks whether the app is running in classic 
+*       desktop mode or single-view mode, and finally creates and assigns the appropriate main window 
+*       or view with its DataContext set to a new instance of MainViewModel.
 *=============================================================================================*/
 
 using Avalonia;

--- a/Morven_Compatch_NFR_Patcher/Converters/PointerOverToImageConverter.cs
+++ b/Morven_Compatch_NFR_Patcher/Converters/PointerOverToImageConverter.cs
@@ -1,34 +1,34 @@
 ﻿/*=============================================================================================*
-* Class: PointerOverToImageConverter
+*   Class: PointerOverToImageConverter
 *
-* Description:
-*   This converter is used to dynamically switch between two different question mark images
-*   based on whether the mouse pointer is hovering over a control (typically a Button).
-*   It implements IValueConverter from Avalonia, converting a boolean value (usually the Button's
-*   IsPointerOver property) into a Bitmap image.
+*   Description:
+*       This converter is used to dynamically switch between two different question mark images
+*       based on whether the mouse pointer is hovering over a control (typically a Button).
+*       It implements IValueConverter from Avalonia, converting a boolean value (usually the Button's
+*       IsPointerOver property) into a Bitmap image.
 *
-*   When the bound value is true (indicating that the pointer is over the control), this 
-*   converter returns a Bitmap loaded from the 'question_mark_hover.png' resource. Otherwise,
-*   it returns a Bitmap loaded from the default 'question_mark.png' resource.
+*       When the bound value is true (indicating that the pointer is over the control), this 
+*       converter returns a Bitmap loaded from the 'question_mark_hover.png' resource. Otherwise,
+*       it returns a Bitmap loaded from the default 'question_mark.png' resource.
 *
-*   The converter uses the static AssetLoader class (introduced in Avalonia 11) to open a stream
-*   for the resource URI and create a Bitmap. Both image files must be correctly located and marked
-*   as AvaloniaResource.
+*       The converter uses the static AssetLoader class (introduced in Avalonia 11) to open a stream
+*       for the resource URI and create a Bitmap. Both image files must be correctly located and marked
+*       as AvaloniaResource.
 *
-* Usage:
-*   Bind the Source property of an Image control to the IsPointerOver property of its parent
-*   Button, using this converter. For example:
+*   Usage:
+*       Bind the Source property of an Image control to the IsPointerOver property of its parent
+*       Button, using this converter. For example:
 *
 *     Source="{Binding IsPointerOver, RelativeSource={RelativeSource AncestorType=Button}, 
 *              Converter={StaticResource PointerOverToImageConverter}}"
 *
-* Dependencies:
-*   - Avalonia.Data.Converters.IValueConverter for data conversion.
-*   - Avalonia.Media.Imaging.Bitmap to represent images.
-*   - Avalonia.Platform.AssetLoader for loading images from the embedded resources.
+*   Dependencies:
+*       - Avalonia.Data.Converters.IValueConverter for data conversion.
+*       - Avalonia.Media.Imaging.Bitmap to represent images.
+*       - Avalonia.Platform.AssetLoader for loading images from the embedded resources.
 *
-* Note:
-*   The ConvertBack method is not implemented, as this converter is intended for one-way binding only.
+*   Note:
+*       The ConvertBack method is not implemented, as this converter is intended for one-way binding only.
 *
 *=============================================================================================*/
 

--- a/Morven_Compatch_NFR_Patcher/Helpers/ConsoleOutputTextHelper.cs
+++ b/Morven_Compatch_NFR_Patcher/Helpers/ConsoleOutputTextHelper.cs
@@ -2,17 +2,21 @@
 *   Class: ConsoleOutputTextHelper
 *
 *   Description: This static class provides helper methods for appending colored text to a TextBlock.
-*      It simplifies the process of adding text with varying colors to a TextBlock's inlines.
-*      The class includes methods for:
-*         - Appending generic colored text (AppendColoredText).
-*         - Displaying a status message (ShowStatusText) based on a status title integer.
-*           The status title determines which status banner to display (e.g., "OK", "ERROR", "CRITICAL ERROR",
-*           "TIP", "PATCH", or "DEBUG").
-*         - Checking the combined length of the status text and custom message, and splitting the message
+*       It simplifies the process of adding text with varying colors to a TextBlock's inlines.
+*       
+*       The class includes methods for:
+*           - Appending generic colored text (AppendColoredText).
+*           - Displaying a status message (ShowStatusText) based on a status title integer.
+*       
+*       The status title determines which status banner to display 
+*       (e.g., "OK", "ERROR", "CRITICAL ERROR","TIP", "PATCH", or "DEBUG").
+*       
+*           - Checking the combined length of the status text and custom message, and splitting the message
 *           into two parts with a line break if the total length exceeds 75 characters (CheckMessageCharacterLimit).
-*         - Parsing the custom message to highlight specific keywords (via AppendColoredTextWithKeywords)
+*           - Parsing the custom message to highlight specific keywords (via AppendColoredTextWithKeywords)
 *           in designated colors.
-*      After displaying the status and processing the message, the method pauses for 300 milliseconds.
+*           
+*       After displaying the status and processing the message, the method pauses for 300 milliseconds.
 *=============================================================================================*/
 
 using Avalonia.Collections;

--- a/Morven_Compatch_NFR_Patcher/Helpers/FileHelper.cs
+++ b/Morven_Compatch_NFR_Patcher/Helpers/FileHelper.cs
@@ -1,9 +1,9 @@
 ﻿/*=============================================================================================*
-* Class: FileHelper
+*   Class: FileHelper
 *
-* Description:
-*   Provides helper methods for file and directory operations.
-*   This class includes methods for copying directories recursively.
+*   Description:
+*       Provides helper methods for file and directory operations.
+*       This class includes methods for copying directories recursively.
 *
 *=============================================================================================*/
 

--- a/Morven_Compatch_NFR_Patcher/Helpers/ModFileUpdater.cs
+++ b/Morven_Compatch_NFR_Patcher/Helpers/ModFileUpdater.cs
@@ -1,17 +1,17 @@
 ﻿/*=============================================================================================*
-* Class: ModFilerUpdater
+*   Class: ModFilerUpdater
 * 
-* Description: ModFileUpdater is a helper class responsible for updating mod descriptor files.
-* It modifies specific lines in the mod files to ensure compatibility with a given game version
+*   Description: ModFileUpdater is a helper class responsible for updating mod descriptor files.
+*   It modifies specific lines in the mod files to ensure compatibility with a given game version
 * 
-* This class performs the following operations:
-* - Locates the mod descriptor files in the "Assets/ModFiles" directory.
-* - Updates the 6th line in "morven_patch_NFR.mod" and "descriptor.mod" with the provided game version.
-* - Ensures the target files exist before attempting modifications.
-* - Provides error handling to prevent unexpected crashes.
+*   This class performs the following operations:
+*       - Locates the mod descriptor files in the "Assets/ModFiles" directory.
+*       - Updates the 6th line in "morven_patch_NFR.mod" and "descriptor.mod" with the provided game version.
+*       - Ensures the target files exist before attempting modifications.
+*       - Provides error handling to prevent unexpected crashes.
 * 
-* Usage:
-* Call ModFileUpdater.UpdateModFiles(gameVersion) to apply the version update.
+*   Usage:
+*   Call ModFileUpdater.UpdateModFiles(gameVersion) to apply the version update.
 *=============================================================================================*/
 
 using System;

--- a/Morven_Compatch_NFR_Patcher/Helpers/VersionHelper.cs
+++ b/Morven_Compatch_NFR_Patcher/Helpers/VersionHelper.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Reflection;
+
+namespace Morven_Compatch_NFR_Patcher.Helpers
+{
+    /// <summary>
+    /// Provides a helper to retrieve the application version as defined by the
+    /// AssemblyInformationalVersion attribute. This temporary version returns
+    /// detailed debug output showing the values of all the variables.
+    /// </summary>
+    public static class VersionHelper
+    {
+        public static string AppVersion
+        {
+            get
+            {
+                // Get the assembly containing VersionHelper.
+                var assembly = typeof(VersionHelper).Assembly;
+                string assemblyName = assembly.FullName;
+
+                // Retrieve the informational version from the assembly attribute.
+                // This is typically set by GitVersion (or Git2SemVer).
+                string rawInfoVersion = assembly
+                    .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+                    .InformationalVersion;
+
+                // Start building our debug output.
+                string debugOutput = "";
+                debugOutput += $"Assembly Name: {assemblyName}\n";
+                debugOutput += $"Raw Informational Version: {rawInfoVersion}\n";
+
+                // If the informational version is missing, return our debug output.
+                if (string.IsNullOrEmpty(rawInfoVersion))
+                {
+                    debugOutput += "Informational Version is empty or null.\n";
+                    return debugOutput;
+                }
+
+                // Look for the '+' character that separates the semantic version from build metadata.
+                int plusIndex = rawInfoVersion.IndexOf('+');
+                debugOutput += $"Index of '+': {plusIndex}\n";
+
+                if (plusIndex >= 0 && plusIndex < rawInfoVersion.Length - 1)
+                {
+                    // Extract the semantic version portion (everything before the '+').
+                    string semVer = rawInfoVersion.Substring(0, plusIndex);
+                    // Extract the build metadata (everything after the '+').
+                    string buildMetadata = rawInfoVersion.Substring(plusIndex + 1);
+
+                    debugOutput += $"Semantic Version (before '+'): {semVer}\n";
+                    debugOutput += $"Build Metadata (after '+'): {buildMetadata}\n";
+
+                    // If the build metadata is longer than 7 characters, trim it.
+                    if (buildMetadata.Length > 7)
+                    {
+                        string trimmedBuildMetadata = buildMetadata.Substring(0, 7);
+                        debugOutput += $"Trimmed Build Metadata: {trimmedBuildMetadata}\n";
+                        string finalVersion = $"{semVer}+{trimmedBuildMetadata}";
+                        debugOutput += $"Final Version: {finalVersion}\n";
+                        return debugOutput;
+                    }
+                    else
+                    {
+                        string finalVersion = $"{semVer}+{buildMetadata}";
+                        debugOutput += $"Final Version: {finalVersion}\n";
+                        return debugOutput;
+                    }
+                }
+                else
+                {
+                    debugOutput += $"No '+' found. Final Version: {rawInfoVersion}\n";
+                    return debugOutput;
+                }
+            }
+        }
+    }
+}

--- a/Morven_Compatch_NFR_Patcher/Helpers/VersionHelper.cs
+++ b/Morven_Compatch_NFR_Patcher/Helpers/VersionHelper.cs
@@ -1,77 +1,91 @@
-﻿using System;
+﻿/*=============================================================================================*
+*   Class: VersionHelper
+*
+*   Description: This static class provides a helper property for retrieving the application version
+*      as defined by the AssemblyInformationalVersion attribute of the executing assembly.
+*      The AppVersion property processes the raw version string to extract a semantic version and a short
+*      SHA commit identifier. The final version is returned in the format:
+*         SemanticVersion + "+" + ShortSha
+*      For example, if the raw version is "v.2.0.1-alpha.THEBEAST.141+hotfix.163c57f", it will be transformed to
+*      "2.0.1-alpha+163c57f". This processing includes:
+*         - Removing a leading "v." if present.
+*         - Truncating the semantic version after the pre-release label if extra identifiers exist.
+*         - Extracting a 7-character short SHA from the build metadata.
+*=============================================================================================*/
+
+using System;
 using System.Reflection;
 
-namespace Morven_Compatch_NFR_Patcher.Helpers
+public static class VersionHelper
 {
-    /// <summary>
-    /// Provides a helper to retrieve the application version as defined by the
-    /// AssemblyInformationalVersion attribute. This temporary version returns
-    /// detailed debug output showing the values of all the variables.
-    /// </summary>
-    public static class VersionHelper
+    public static string AppVersion
     {
-        public static string AppVersion
+        get
         {
-            get
+            // Get the assembly that contains this helper class.
+            var assembly = typeof(VersionHelper).Assembly;
+
+            // Retrieve the informational version from the assembly attribute.
+            // This attribute is typically set by versioning tools such as GitVersion or Git2SemVer.
+            string rawInfoVersion = assembly
+                .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+                .InformationalVersion;
+
+            // If the informational version is missing, return a default message.
+            if (string.IsNullOrEmpty(rawInfoVersion))
             {
-                // Get the assembly containing VersionHelper.
-                var assembly = typeof(VersionHelper).Assembly;
-                string assemblyName = assembly.FullName;
+                return "Version not available";
+            }
 
-                // Retrieve the informational version from the assembly attribute.
-                // This is typically set by GitVersion (or Git2SemVer).
-                string rawInfoVersion = assembly
-                    .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
-                    .InformationalVersion;
+            // Find the '+' character that separates the semantic version from the build metadata.
+            int plusIndex = rawInfoVersion.IndexOf('+');
+            if (plusIndex < 0)
+            {
+                // If no '+' is found, return the raw version string.
+                return rawInfoVersion;
+            }
 
-                // Start building our debug output.
-                string debugOutput = "";
-                debugOutput += $"Assembly Name: {assemblyName}\n";
-                debugOutput += $"Raw Informational Version: {rawInfoVersion}\n";
+            // Extract the semantic version (everything before the '+').
+            string semVer = rawInfoVersion.Substring(0, plusIndex);
 
-                // If the informational version is missing, return our debug output.
-                if (string.IsNullOrEmpty(rawInfoVersion))
+            // Remove a leading "v." if present.
+            if (semVer.StartsWith("v."))
+            {
+                semVer = semVer.Substring(2);
+            }
+
+            // If the semantic version contains extra identifiers after the pre-release label,
+            // trim it so only the pre-release label remains.
+            // For example: "2.0.1-alpha.THEBEAST.141" becomes "2.0.1-alpha".
+            int hyphenIndex = semVer.IndexOf('-');
+            if (hyphenIndex >= 0)
+            {
+                int dotAfterHyphen = semVer.IndexOf('.', hyphenIndex);
+                if (dotAfterHyphen > 0)
                 {
-                    debugOutput += "Informational Version is empty or null.\n";
-                    return debugOutput;
-                }
-
-                // Look for the '+' character that separates the semantic version from build metadata.
-                int plusIndex = rawInfoVersion.IndexOf('+');
-                debugOutput += $"Index of '+': {plusIndex}\n";
-
-                if (plusIndex >= 0 && plusIndex < rawInfoVersion.Length - 1)
-                {
-                    // Extract the semantic version portion (everything before the '+').
-                    string semVer = rawInfoVersion.Substring(0, plusIndex);
-                    // Extract the build metadata (everything after the '+').
-                    string buildMetadata = rawInfoVersion.Substring(plusIndex + 1);
-
-                    debugOutput += $"Semantic Version (before '+'): {semVer}\n";
-                    debugOutput += $"Build Metadata (after '+'): {buildMetadata}\n";
-
-                    // If the build metadata is longer than 7 characters, trim it.
-                    if (buildMetadata.Length > 7)
-                    {
-                        string trimmedBuildMetadata = buildMetadata.Substring(0, 7);
-                        debugOutput += $"Trimmed Build Metadata: {trimmedBuildMetadata}\n";
-                        string finalVersion = $"{semVer}+{trimmedBuildMetadata}";
-                        debugOutput += $"Final Version: {finalVersion}\n";
-                        return debugOutput;
-                    }
-                    else
-                    {
-                        string finalVersion = $"{semVer}+{buildMetadata}";
-                        debugOutput += $"Final Version: {finalVersion}\n";
-                        return debugOutput;
-                    }
-                }
-                else
-                {
-                    debugOutput += $"No '+' found. Final Version: {rawInfoVersion}\n";
-                    return debugOutput;
+                    semVer = semVer.Substring(0, dotAfterHyphen);
                 }
             }
+
+            // Extract the build metadata (everything after the '+').
+            string buildMetadata = rawInfoVersion.Substring(plusIndex + 1);
+
+            // Look for a '.' in the build metadata which separates a prefix from the SHA.
+            int dotIndex = buildMetadata.IndexOf('.');
+            string shortSha = "";
+            if (dotIndex >= 0 && buildMetadata.Length >= dotIndex + 1 + 7)
+            {
+                // If found, take the 7 characters immediately after the dot as the ShortSha.
+                shortSha = buildMetadata.Substring(dotIndex + 1, 7);
+            }
+            else
+            {
+                // Fallback: use the first 7 characters of buildMetadata.
+                shortSha = buildMetadata.Length > 7 ? buildMetadata.Substring(0, 7) : buildMetadata;
+            }
+
+            // Construct and return the final version string in the format: SemanticVersion + "+" + ShortSha.
+            return $"{semVer}+{shortSha}";
         }
     }
 }

--- a/Morven_Compatch_NFR_Patcher/Morven_Compatch_NFR_Patcher.csproj
+++ b/Morven_Compatch_NFR_Patcher/Morven_Compatch_NFR_Patcher.csproj
@@ -1,56 +1,34 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
-	<!-- Main project properties -->
 	<PropertyGroup>
-
-		<!-- Target .NET 8.0 with nullable enabled and latest C# language version -->
+		
+		<!-- Target .NET 8.0 with nullable enabled and the latest C# language version -->
 		<TargetFramework>net8.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<LangVersion>latest</LangVersion>
-
+		
 		<!-- This project produces a library -->
 		<OutputType>Library</OutputType>
-
-		<!-- Enable GitVersion -->
-		<UseGitVersion>true</UseGitVersion>
-
-		<!-- Version properties will be set automatically by GitVersion.MsBuild -->
-		<Version>$(GitVersion_SemVer)</Version>
-		<AssemblyVersion>$(GitVersion_AssemblySemVer)</AssemblyVersion>
-		<FileVersion>$(GitVersion_AssemblySemFileVer)</FileVersion>
-		<InformationalVersion>$(GitVersion_InformationalVersion)</InformationalVersion>
-
+		
 	</PropertyGroup>
 
-	<!-- Package references -->
 	<ItemGroup>
-
-		<!-- Include Avalonia resource files  -->
+		
+		<!-- Include Avalonia resource files -->
 		<AvaloniaResource Include="Assets\**" />
 		
 		<!-- Avalonia packages for UI functionality -->
-		
 		<PackageReference Include="Avalonia" Version="11.2.4" />
 		<PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.4" />
 		<PackageReference Include="Avalonia.Fonts.Inter" Version="11.2.4" />
 		
-		<!-- CommunityToolkit.Mvvm for MVVM helpers -->
+		<!-- MVVM helpers from CommunityToolkit -->
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
 		
-		<!-- GitVersion.MsBuild integrates GitVersion into the build process -->
-		<PackageReference Include="GitVersion.MsBuild" Version="6.1.0" PrivateAssets="all" />
-		
-		<!-- Include Avalonia.Diagnostics only during Debug builds -->
+		<!-- Avalonia.Diagnostics for Debug builds -->
 		<PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.2.4" />
 		
+		<!-- Git2SemVer integration (A modified version of MSBuild to work with Visual Studio 6.0+) -->
+		<PackageReference Include="NoeticTools.Git2SemVer.MSBuild" Version="2.0.0" />
+		
 	</ItemGroup>
-
-	<!-- Optional: A target that prints GitVersion values to the build output -->
-	<Target Name="ShowGitVersion" AfterTargets="CalculateGitVersion" Condition="'$(DesignTimeBuild)' != 'true'">
-		<Message Text="GitVersion_SemVer: $(GitVersion_SemVer)" Importance="High" />
-		<Message Text="GitVersion_AssemblySemVer: $(GitVersion_AssemblySemVer)" Importance="High" />
-		<Message Text="GitVersion_AssemblySemFileVer: $(GitVersion_AssemblySemFileVer)" Importance="High" />
-		<Message Text="GitVersion_InformationalVersion: $(GitVersion_InformationalVersion)" Importance="High" />
-	</Target>
-
 </Project>

--- a/Morven_Compatch_NFR_Patcher/Morven_Compatch_NFR_Patcher.sln
+++ b/Morven_Compatch_NFR_Patcher/Morven_Compatch_NFR_Patcher.sln
@@ -13,7 +13,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\.gitignore = ..\.gitignore
 		CHANGELOG.MD = CHANGELOG.MD
 		..\Directory.Build.props = ..\Directory.Build.props
-		..\gitversion.json = ..\gitversion.json
+		obj\gitversion.json = obj\gitversion.json
 		..\GitVersion.yml = ..\GitVersion.yml
 		README.MD = README.MD
 	EndProjectSection

--- a/Morven_Compatch_NFR_Patcher/ViewModels/InfoDialogViewModel.cs
+++ b/Morven_Compatch_NFR_Patcher/ViewModels/InfoDialogViewModel.cs
@@ -1,9 +1,9 @@
 ﻿/*=============================================================================================*
-* Class: InfoDialogViewModel
+*   Class: InfoDialogViewModel
 *
-* Description:
-*   This ViewModel is responsible for providing the data for the InfoDialog.
-*   It includes a Message property that notifies the UI when changed.
+*   Description:
+*       This ViewModel is responsible for providing the data for the InfoDialog.
+*       It includes a Message property that notifies the UI when changed.
 *=============================================================================================*/
 
 using CommunityToolkit.Mvvm.ComponentModel;

--- a/Morven_Compatch_NFR_Patcher/ViewModels/MainViewModel.cs
+++ b/Morven_Compatch_NFR_Patcher/ViewModels/MainViewModel.cs
@@ -1,7 +1,7 @@
 ﻿/*=============================================================================================*
 * Class: MainViewModel
 *
-* Description: 
+*   Description: 
 *   This ViewModel serves as the primary data context for the main UI. It holds the 
 *   folder paths for the Steam folder and mod folder, and provides computed properties:
 *   - 'CanPatch' indicates whether both folders have been specified.

--- a/Morven_Compatch_NFR_Patcher/ViewModels/MainViewModel.cs
+++ b/Morven_Compatch_NFR_Patcher/ViewModels/MainViewModel.cs
@@ -5,7 +5,6 @@
 *   This ViewModel serves as the primary data context for the main UI. It holds the 
 *   folder paths for the Steam folder and mod folder, and provides computed properties:
 *   - 'CanPatch' indicates whether both folders have been specified.
-*   - 'AppVersion' retrieves the application's version from the executing assembly.
 *
 *   The class inherits from ViewModelBase, which in turn inherits from ObservableObject.
 *   ObservableObject implements INotifyPropertyChanged so that the UI automatically updates 
@@ -16,6 +15,7 @@
 using System;
 using System.Reflection;
 using CommunityToolkit.Mvvm.ComponentModel;
+using Morven_Compatch_NFR_Patcher.Helpers;
 
 namespace Morven_Compatch_NFR_Patcher.ViewModels
 {
@@ -29,43 +29,10 @@ namespace Morven_Compatch_NFR_Patcher.ViewModels
         [ObservableProperty]
         private string modFolder = string.Empty;
 
+        public string AppVersion => VersionHelper.AppVersion;
+
         // CanPatch returns true only if both SteamFolder and ModFolder are not null or whitespace.
         public bool CanPatch => !string.IsNullOrWhiteSpace(SteamFolder) && !string.IsNullOrWhiteSpace(ModFolder);
-
-        // AppVersion retrieves the application's version from the executing assembly.
-        public static string AppVersion
-        {
-            get
-            {
-                // Use the entry assembly (the exe) if available; otherwise, use the executing assembly.
-                var assembly = Assembly.GetEntryAssembly() ?? Assembly.GetExecutingAssembly();
-                var infoVersion = assembly
-                    .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
-                    .InformationalVersion;
-
-                if (string.IsNullOrEmpty(infoVersion))
-                    return "N/A";
-
-                // Look for a '+' sign (which indicates build metadata in semver).
-                int plusIndex = infoVersion.IndexOf('+');
-                if (plusIndex != -1 && plusIndex < infoVersion.Length - 1)
-                {
-                    // Efficiently slice the version string to include only 7 characters of build metadata.
-                    ReadOnlySpan<char> infoSpan = infoVersion.AsSpan();
-                    ReadOnlySpan<char> prefix = infoSpan[..(plusIndex + 1)];
-                    ReadOnlySpan<char> metadataSpan = infoSpan[(plusIndex + 1)..];
-
-                    if (metadataSpan.Length > 7)
-                    {
-                        metadataSpan = metadataSpan[..7];
-                    }
-
-                    infoVersion = string.Concat(prefix, metadataSpan);
-                }
-
-                return infoVersion;
-            }
-        }
 
         // This method is automatically called when the SteamFolder property changes. It notifies the UI that the CanPatch property may have changed.
         partial void OnSteamFolderChanged(string value)

--- a/Morven_Compatch_NFR_Patcher/ViewModels/ViewModelBase.cs
+++ b/Morven_Compatch_NFR_Patcher/ViewModels/ViewModelBase.cs
@@ -1,12 +1,12 @@
 ﻿/*=============================================================================================*
-* Class: ViewModelBase
+*   Class: ViewModelBase
 *
-* Description: Serves as a base class for all ViewModel classes in the application.
-* It inherits from ObservableObject, which implements INotifyPropertyChanged.
-* This provides built-in support for property change notifications,
-* enabling the UI to update automatically when properties in the ViewModel change.
+*   Description: Serves as a base class for all ViewModel classes in the application.
+*   It inherits from ObservableObject, which implements INotifyPropertyChanged.
+*   This provides built-in support for property change notifications,
+*   enabling the UI to update automatically when properties in the ViewModel change.
 *
-* Note: Although no additional code is present now, any ViewModel that derives from ViewModelBase
+*   Note: Although no additional code is present now, any ViewModel that derives from ViewModelBase
 *       will have the necessary functionality for data binding, and common functionality can be added here in the future.
 *=============================================================================================*/
 using CommunityToolkit.Mvvm.ComponentModel;

--- a/Morven_Compatch_NFR_Patcher/Views/MainView.axaml
+++ b/Morven_Compatch_NFR_Patcher/Views/MainView.axaml
@@ -10,19 +10,21 @@
     Line 24 : Sets the default XML namespace for Avalonia UI elements.
     Line 25 : Provides XAML language constructs (e.g. x:Class, x:Name, etc.).
     Line 26 : Used for design-time properties and data in Visual Studio.
-    Line 27 : Maps the 'local' prefix to the CLR namespace that contains the Converters.
-    Line 28 : Enables markup compatibility features, such as ignoring design-time attributes at runtime.
-    Line 29 : Maps the 'vm' prefix to the CLR namespace that contains the ViewModels.
-    Line 30 : Specifies the design-time height for the control in the designer.
+    Line 27 : Maps the 'helpers' prefix to the CLR namespace that contains the Helpers.
+    Line 28 : Maps the 'local' prefix to the CLR namespace that contains the Converters.
+    Line 29 : Enables markup compatibility features, such as ignoring design-time attributes at runtime.
+    Line 30 : Maps the 'vm' prefix to the CLR namespace that contains the ViewModels.
+    Line 31 : Specifies the design-time height for the control in the designer.
     Line 32 : Specifies the design-time width for the control in the designer.
     Line 33 : Declares that the DataContext for this UserControl is of type 'MainViewModel' for compile-time binding checks.
-    Line 33 : Instructs the XAML parser to ignore all attributes in the 'd' (design-time) namespace at runtime.
+    Line 34 : Instructs the XAML parser to ignore all attributes in the 'd' (design-time) namespace at runtime.
 -->
 <UserControl
     x:Class="Morven_Compatch_NFR_Patcher.Views.MainView"
     xmlns="https://github.com/avaloniaui"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:helpers="clr-namespace:Morven_Compatch_NFR_Patcher.Helpers"
     xmlns:local="clr-namespace:Morven_Compatch_NFR_Patcher.Converters"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:vm="clr-namespace:Morven_Compatch_NFR_Patcher.ViewModels"
@@ -405,13 +407,14 @@
                 </Button.Transitions>
             </Button>
 
-            <!--  Version Info.  -->
+            <!--  Version Info  -->
             <TextBlock
                 Grid.Row="1"
                 HorizontalAlignment="Right"
                 VerticalAlignment="Bottom"
                 FontSize="13"
                 Text="{Binding AppVersion, StringFormat='v{0} by Tygrtraxx'}" />
+
         </Grid>
     </Grid>
 </UserControl>

--- a/Morven_Compatch_NFR_Patcher/Views/MainView.axaml.cs
+++ b/Morven_Compatch_NFR_Patcher/Views/MainView.axaml.cs
@@ -1,10 +1,10 @@
 ﻿/*=============================================================================================*
-* Class: MainView
+*   Class: MainView
 *
-* Description:
-*   This is the code-behind for the MainView UserControl. It initializes the UI components
-*   defined in the associated XAML file (MainView.axaml) and handles user interactions,
-*   such as clicks on the question mark buttons which display an InfoDialog.
+*   Description:
+*       This is the code-behind for the MainView UserControl. It initializes the UI components
+*       defined in the associated XAML file (MainView.axaml) and handles user interactions,
+*       such as clicks on the question mark buttons which display an InfoDialog.
 *=============================================================================================*/
 
 using System;
@@ -18,11 +18,10 @@ using Avalonia.Interactivity;
 using Avalonia.VisualTree;
 using Avalonia.Platform.Storage;
 using Avalonia.Threading;
-using Morven_Compatch_NFR_Patcher.ViewModels;
-using Morven_Compatch_NFR_Patcher.Helpers;
 using Avalonia.Media;
 using Avalonia.Controls.Converters;
-
+using Morven_Compatch_NFR_Patcher.ViewModels;
+using Morven_Compatch_NFR_Patcher.Helpers;
 
 namespace Morven_Compatch_NFR_Patcher.Views
 {


### PR DESCRIPTION
Fix the version number bug by enabling GitVersion integration by Git2SemVer (a modified version
    of MSBuild for Visual Studio 6.0+) instead of MSBuild (Depreciated library as of 6.0).